### PR TITLE
Build Mono framework from source

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -19,32 +19,32 @@ jobs:
       fail-fast: false 
       matrix:
         include:
-          # - version: "0.9.2.0"
-          #   tag: >
-          #     soupbowl/opensimulator:0.9.2.0,
-          #     ghcr.io/${{ github.repository }}:0.9.2.0,
-          #   folder: build/latest
-          #   file: Dockerfile.mono
-          #   platforms: linux/amd64,linux/arm64
-          #   sha1: 584966ef6029f21dc842a7f55f6f117b3a0b0321
-          # - version: "0.9.2.1"
-          #   tag: >
-          #     soupbowl/opensimulator:0.9.2.1,
-          #     ghcr.io/${{ github.repository }}:0.9.2.1,
-          #   folder: build/latest
-          #   file: Dockerfile.mono
-          #   platforms: linux/amd64,linux/arm64
-          #   sha1: c5d2e690a7739fa9c0651845b31d912f88d6fa22
-          # - version: "0.9.2.2"
-          #   tag: >
-          #     soupbowl/opensimulator:0.9.2,
-          #     soupbowl/opensimulator:0.9.2.2,
-          #     ghcr.io/${{ github.repository }}:0.9.2,
-          #     ghcr.io/${{ github.repository }}:0.9.2.2,
-          #   folder: build/latest
-          #   file: Dockerfile.mono
-          #   platforms: linux/amd64,linux/arm64
-          #   sha1: b280d109cf04755a02db1c729af5a5e4160d1ce6
+          - version: "0.9.2.0"
+            tag: >
+              soupbowl/opensimulator:0.9.2.0,
+              ghcr.io/${{ github.repository }}:0.9.2.0,
+            folder: build/latest
+            file: Dockerfile.mono
+            platforms: linux/amd64,linux/arm64
+            sha1: 584966ef6029f21dc842a7f55f6f117b3a0b0321
+          - version: "0.9.2.1"
+            tag: >
+              soupbowl/opensimulator:0.9.2.1,
+              ghcr.io/${{ github.repository }}:0.9.2.1,
+            folder: build/latest
+            file: Dockerfile.mono
+            platforms: linux/amd64,linux/arm64
+            sha1: c5d2e690a7739fa9c0651845b31d912f88d6fa22
+          - version: "0.9.2.2"
+            tag: >
+              soupbowl/opensimulator:0.9.2,
+              soupbowl/opensimulator:0.9.2.2,
+              ghcr.io/${{ github.repository }}:0.9.2,
+              ghcr.io/${{ github.repository }}:0.9.2.2,
+            folder: build/latest
+            file: Dockerfile.mono
+            platforms: linux/amd64,linux/arm64
+            sha1: b280d109cf04755a02db1c729af5a5e4160d1ce6
           - version: "0.9.3.0"
             tag: >
               soupbowl/opensimulator:latest,

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ This **unofficial** Docker configuration aims to assist in setting the server up
 
 **This is still experimental - thar be bugs!**
 
-> [!IMPORTANT]  
-> **[Mono has been discontinued](https://github.com/soup-bowl/opensimulator-docker/issues/10)** - for the foreseeable 0.9.2.2 and below images **will not be updated**. Until a maintainer or suitable alternative is found, they are **not supported**.
 
 > [!WARNING]  
 > 0.9.3.0 (and in turn latest) is a significant change from 0.9.2.2 and below. Mono is no longer used, and has been replaced with the .NET Framework. This changes some aspects of the image, such as the ENTRYPOINT and source builds, so please test before switching over. If you wish to remain, 0.9.2.2 will continue to be updated and remains on the Mono base. For more information, see the [official release notes](http://opensimulator.org/wiki/0.9.3.0) and this [PR for Dockerfile changes](https://github.com/soup-bowl/opensimulator-docker/pull/8/files).
@@ -30,11 +28,11 @@ This **unofficial** Docker configuration aims to assist in setting the server up
 
 -	[`0.9.3-noscreen`, `0.9.3.0-noscreen`](https://github.com/soup-bowl/opensimulator-docker/blob/main/build/latest/Dockerfile.noscreen)
 
--	[`0.9.2`, `0.9.2.2`](https://github.com/soup-bowl/opensimulator-docker/blob/main/build/latest/Dockerfile.mono) (unsupported)
+-	[`0.9.2`, `0.9.2.2`](https://github.com/soup-bowl/opensimulator-docker/blob/main/build/latest/Dockerfile.mono)
 
--	[`0.9.2.1`](https://github.com/soup-bowl/opensimulator-docker/blob/main/build/latest/Dockerfile.mono) (unsupported)
+-	[`0.9.2.1`](https://github.com/soup-bowl/opensimulator-docker/blob/main/build/latest/Dockerfile.mono)
 
--	[`source`](https://github.com/soup-bowl/opensimulator-docker/blob/main/beta/source/Dockerfile) (unsupported)
+-	[`source`](https://github.com/soup-bowl/opensimulator-docker/blob/main/beta/source/Dockerfile)
 
 -	[`alpine-beta`](https://github.com/soup-bowl/opensimulator-docker/blob/main/beta/alpine/Dockerfile)
 
@@ -130,7 +128,7 @@ Variant names are listed in Dockerhub format. They are also available from the G
 
 The latest OpenSimulator image build using [official .NET 8 image](https://mcr.microsoft.com/en-us/product/dotnet/runtime/about) as the build reference.
 
-If you pull from **0.9.2.2** or below, you will instead be using the [Mono Framework](https://hub.docker.com/_/mono/). **As of August 2025 these are not supported** as Mono framework has been discontinued.
+If you pull from **0.9.2.2** or below, you will instead be using the [Mono Framework](https://hub.docker.com/_/mono/).
 
 ## `soupbowl/opensimulator:<version>-noscreen`
 

--- a/build/latest/Dockerfile.mono
+++ b/build/latest/Dockerfile.mono
@@ -71,5 +71,5 @@ WORKDIR /opt/opensim/bin
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
-#ENTRYPOINT ["docker-entrypoint.sh"]
-#CMD [ "mono", "./OpenSim.exe" ]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD [ "mono", "./OpenSim.exe" ]

--- a/build/latest/Dockerfile.mono
+++ b/build/latest/Dockerfile.mono
@@ -45,8 +45,7 @@ COPY --from=mono-build /opt/mono /opt/mono
 # Make mono available on PATH and install runtime utilities
 RUN apt-get update \
 	&& apt-get install --no-install-recommends -y ca-certificates curl screen uuid-runtime libglib2.0-0 libgnutls30 tzdata \
-	 && ln -s /opt/mono/bin/mono /usr/local/bin/mono \
-		 libgdiplus libfontconfig1 libx11-6 \
+	&& ln -s /opt/mono/bin/mono /usr/local/bin/mono \
 	&& ln -s /opt/mono/bin/mono-sgen /usr/local/bin/mono-sgen || true \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*

--- a/build/latest/Dockerfile.mono
+++ b/build/latest/Dockerfile.mono
@@ -1,6 +1,34 @@
-FROM docker.io/library/mono:6
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# Build stage: compile Mono from WineHQ mono-6.14.1 source on Ubuntu
+FROM ubuntu:22.04 AS mono-build
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG MONO_VERSION=mono-6.14.1
+
+RUN apt-get update \
+	 && apt-get install -y --no-install-recommends \
+		 build-essential autoconf automake libtool pkg-config cmake git wget ca-certificates \
+	   gettext libglib2.0-dev libssl-dev libx11-dev libxrandr-dev libxfixes-dev libxext-dev \
+	   libasound2-dev libgcrypt20-dev libpng-dev libjpeg-dev libtiff-dev libpango1.0-dev \
+	   libfreetype6-dev libffi-dev zlib1g-dev curl && \
+	rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+# Clone the Mono repository (with submodules) and build it. Using git
+# ensures external/submodule directories like bdwgc are fetched.
+RUN set -eux; \
+	git clone --depth 1 --branch "${MONO_VERSION}" --recursive https://gitlab.winehq.org/mono/mono.git /mono-src; \
+	cd /mono-src; \
+	./autogen.sh --prefix=/opt/mono; \
+	make -j"$(nproc)"; \
+	make install; \
+	rm -rf /mono-src
+
+
+# Final image: start from a minimal Ubuntu and copy only the runtime files
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL \
 	org.opencontainers.image.title="OpenSimulator (unofficial)" \
@@ -11,11 +39,21 @@ LABEL \
 ARG OPENSIM_VERSION=0.9.2.2
 ARG OPENSIM_SHA1="b280d109cf04755a02db1c729af5a5e4160d1ce6"
 
+# Copy the built mono runtime from the build stage
+COPY --from=mono-build /opt/mono /opt/mono
+
+# Make mono available on PATH and install runtime utilities
 RUN apt-get update \
-	&& apt-get install --no-install-recommends -y curl screen uuid-runtime \
+	&& apt-get install --no-install-recommends -y ca-certificates curl screen uuid-runtime libglib2.0-0 libgnutls30 tzdata \
+	 && ln -s /opt/mono/bin/mono /usr/local/bin/mono \
+		 libgdiplus libfontconfig1 libx11-6 \
+	&& ln -s /opt/mono/bin/mono-sgen /usr/local/bin/mono-sgen || true \
 	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& mkdir /opt/opensim-tmp \
+	&& rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir /opt/opensim-tmp \
 	&& curl -o /opt/opensim-tmp/opensim.tar.gz "http://opensimulator.org/dist/opensim-${OPENSIM_VERSION}.tar.gz" \
 	&& echo "${OPENSIM_SHA1}  /opt/opensim-tmp/opensim.tar.gz" | sha1sum -c - \
 	&& tar xzf /opt/opensim-tmp/opensim.tar.gz -C /opt/opensim-tmp \
@@ -23,7 +61,8 @@ RUN apt-get update \
 	&& rm /opt/opensim-tmp/opensim*/bin/config-include/StandaloneCommon.ini \
 	&& rm /opt/opensim-tmp/opensim*/bin/config-include/storage/SQLiteStandalone.ini \
 	&& mkdir /opt/opensim \
-	&& mv /opt/opensim-tmp/opensim*/* /opt/opensim
+	&& mv /opt/opensim-tmp/opensim*/* /opt/opensim \
+	&& rm -rf /opt/opensim-tmp
 
 COPY defaults  /opt/opensim/bin/defaults
 
@@ -33,5 +72,5 @@ WORKDIR /opt/opensim/bin
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT ["docker-entrypoint.sh"]
-CMD [ "mono", "./OpenSim.exe" ]
+#ENTRYPOINT ["docker-entrypoint.sh"]
+#CMD [ "mono", "./OpenSim.exe" ]

--- a/build/latest/Dockerfile.mono
+++ b/build/latest/Dockerfile.mono
@@ -44,7 +44,7 @@ COPY --from=mono-build /opt/mono /opt/mono
 
 # Make mono available on PATH and install runtime utilities
 RUN apt-get update \
-	&& apt-get install --no-install-recommends -y ca-certificates curl screen uuid-runtime libglib2.0-0 libgnutls30 tzdata \
+	&& apt-get install --no-install-recommends -y ca-certificates curl screen uuid-runtime libglib2.0-0 libgnutls30 tzdata libgdiplus libfontconfig1 \
 	&& ln -s /opt/mono/bin/mono /usr/local/bin/mono \
 	&& ln -s /opt/mono/bin/mono-sgen /usr/local/bin/mono-sgen || true \
 	&& apt-get clean \

--- a/build/latest/Dockerfile.mono
+++ b/build/latest/Dockerfile.mono
@@ -1,6 +1,5 @@
 
-# Build stage: compile Mono from WineHQ mono-6.14.1 source on Ubuntu
-FROM ubuntu:22.04 AS mono-build
+FROM debian:bookworm-slim AS mono-build
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG MONO_VERSION=mono-6.14.1
@@ -15,8 +14,6 @@ RUN apt-get update \
 
 WORKDIR /tmp
 
-# Clone the Mono repository (with submodules) and build it. Using git
-# ensures external/submodule directories like bdwgc are fetched.
 RUN set -eux; \
 	git clone --depth 1 --branch "${MONO_VERSION}" --recursive https://gitlab.winehq.org/mono/mono.git /mono-src; \
 	cd /mono-src; \
@@ -26,8 +23,7 @@ RUN set -eux; \
 	rm -rf /mono-src
 
 
-# Final image: start from a minimal Ubuntu and copy only the runtime files
-FROM ubuntu:22.04
+FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL \


### PR DESCRIPTION
Deals with #10 - The Mono base image the 0.9.2.2 and below inherits from is just technically an installed apt dependency, and since it comes from the Mono framework it has been deprecated. However, WineHQ has begun supporting it in absense of the foundation.

This PR builds a base image where the Mono framework is compiled, allowing the 0.9.2.2 legacy builds to continue running.

I have no idea why I'm doing this.